### PR TITLE
Update BTS download URL in flights.R

### DIFF
--- a/data-raw/flights.R
+++ b/data-raw/flights.R
@@ -2,7 +2,7 @@ library(dplyr)
 library(readr)
 
 flight_url <- function(year = 2013, month) {
-  base_url <- "http://www.transtats.bts.gov/Download/"
+  base_url <- "http://www.transtats.bts.gov/PREZIP/"
   sprintf(paste0(base_url, "On_Time_On_Time_Performance_%d_%d.zip"), year, month)
 }
 


### PR DESCRIPTION
The base URL for downloading zipped on-time performance data from the US Bureau of Transportation Statistics has changed from `http://www.transtats.bts.gov/Download/` to `http://www.transtats.bts.gov/PREZIP/`. This PR updates that base URL in data-raw/flights.R.