### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@
 [![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/nycflights13)](https://cran.r-project.org/package=nycflights13)
 
 This package contains information about all flights that departed from NYC
-(e.g. EWR, JFK and LGA) in 2013: 336,776 flights in total. To help understand 
-what causes delays, it also includes a number of other useful datasets.
+(e.g. EWR, JFK and LGA) to destinations in the United States, Puerto Rico,
+and the American Virgin Islands) in 2013: 
+336,776 flights in total. To help understand what causes delays, 
+it also includes a number of other useful datasets.
+
 This package provides the following data tables.
 
 * `flights`: all flights that departed from NYC in 2013
@@ -17,7 +20,7 @@ This package provides the following data tables.
 If you're interested in other subsets of flight data, see:
 
 * [nycflights](https://github.com/jayleetx/nycflights) for flights departing 
-  from from NYC in the _last_ year.
+  from NYC in the _last_ year.
   
 * [anyflights](https://github.com/simonpcouch/anyflights) for flights departing
   from any airport in any year.


### PR DESCRIPTION
Add more specificity to data set description (not actually _all_ flights). Remove duplicate "from".

``` r
library(tidyverse)
library(vroom)
iata_codes_link <- "https://pkgstore.datahub.io/core/airport-codes/airport-codes_csv/data/03bb867ce259317ba1503b68a91c5fc2/airport-codes_csv.csv"
iata_codes <- vroom::vroom(file = iata_codes_link) 
#> Observations: 40,892
#> Variables: 12
#> chr [11]: ident, type, name, continent, iso_country, iso_region, municipality, gps_co...
#> dbl [ 1]: elevation_ft
#> 
#> Call `spec()` for a copy-pastable column specification
#> Specify the column types with `col_types` to quiet this message
nycflights13::flights %>% 
  distinct(dest) %>%
  left_join(iata_codes, by = c("dest" = "iata_code")) %>%
  distinct(iso_country)
#> # A tibble: 4 x 1
#>   iso_country
#>   <chr>      
#> 1 US         
#> 2 PR         
#> 3 <NA>       
#> 4 VI
```
